### PR TITLE
Add attributes to js()

### DIFF
--- a/helpers/asset_helper.php
+++ b/helpers/asset_helper.php
@@ -283,13 +283,20 @@ if ( ! function_exists('less'))
  * Creates the <script> tag that links all requested js file
  * @access  public
  * @param   string
+ * @param 	array 	$atts Optional, additional key/value attributes to include in the SCRIPT tag
  * @return  string
  */
 if ( ! function_exists('js'))
 {
-    function js($file)
+    function js($file, $atts = array())
     {
-        return '<script type="text/javascript" src="' . js_url() . $file . '"></script>'."\n";
+        $element = '<script type="text/javascript" src="' . js_url() . $file . '"';
+		
+		foreach ( $atts as $key => $val )
+			$element .= ' ' . $key . '="' . $val . '"';
+		$element .= '></script>'."\n";
+		
+		return $element;
     }
 }
 


### PR DESCRIPTION
It is sometimes useful to add addtional attributes to a script tag.

For example, when using require.js, a **data-main** attribute is typically used.

This change lets you easily add custom attributes to the script element, much as you can for image elements already.

I don't know if any other helpers would benefit from a similar
change, so I let them be.
